### PR TITLE
Feature: 랜덤채팅 기능 추가

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import JournalPage from '../pages/JournalPage'
 import CreateCharacterPage from '../pages/CreateCharacterPage'
 import SelectCharacterPage from '../pages/SelectCharacterPage'
 import CustomizeCharacterPage from '../pages/CustomizeCharacterPage'
+import RandomChatPage from '../pages/RandomChatPage'
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
         <Route path="/create-character" element={<CreateCharacterPage />} />
         <Route path="/select-character" element={<SelectCharacterPage/>}/>
         <Route path="/customize-character" element={<CustomizeCharacterPage/>}/>
+        <Route path="/random-chat" element={<RandomChatPage/>}/>
       </Routes>
     </BrowserRouter>
   )

--- a/src/pages/RandomChatPage.tsx
+++ b/src/pages/RandomChatPage.tsx
@@ -1,0 +1,399 @@
+import { useState, useRef, useEffect } from 'react'
+import { useWebSocket } from '../shared/hooks/useWebSocket'
+import { useRandomChatStore } from '../shared/stores/randomChatStore'
+import { MainLayout } from '../shared/ui'
+import SystemModal from '../shared/ui/SystemModal'
+import AlertModal from '../shared/ui/AlertModal'
+import welcomeIcon from '../shared/assets/images/welcome-icon.png'
+
+const MAX_MESSAGE_LENGTH = 1000
+
+function RandomChatPage() {
+  const { send, exitRoom, reconnect } = useWebSocket()
+  const { status, messages, error, setError, reset } = useRandomChatStore()
+
+  const [inputValue, setInputValue] = useState('')
+  const [showExitModal, setShowExitModal] = useState(false)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  // 새 메시지 시 자동 스크롤
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const handleJoinQueue = () => {
+    send({ type: 'JOIN_QUEUE' })
+  }
+
+  const handleLeaveQueue = () => {
+    send({ type: 'LEAVE_QUEUE' })
+  }
+
+  const handleSendMessage = () => {
+    const content = inputValue.trim()
+    if (!content || status !== 'chatting') return
+
+    send({ type: 'SEND_MESSAGE', content })
+
+    // 서버 ACK 없음 - 클라이언트에서 직접 추가
+    useRandomChatStore.getState().addMessage({
+      id: `me-${Date.now()}`,
+      content,
+      timestamp: Date.now(),
+      sender: 'me',
+    })
+
+    setInputValue('')
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.nativeEvent.isComposing) return // 한글 등 IME 조합 중이면 무시
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSendMessage()
+    }
+  }
+
+  // EXIT_ROOM: 서버 응답 없음. 즉시 초기 화면 전환.
+  const handleExitConfirm = () => {
+    setShowExitModal(false)
+    exitRoom()
+  }
+
+  // 새 채팅 시작 (partner_left 상태에서)
+  const handleNewChat = () => {
+    reset()
+    handleJoinQueue()
+  }
+
+  // 돌아가기 (partner_left 상태에서)
+  const handleBackToIdle = () => {
+    reset()
+  }
+
+  const formatTime = (timestamp: number) => {
+    const date = new Date(timestamp)
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    }).toLowerCase()
+  }
+
+  // 채팅 중이거나 상대가 나간 상태에서 채팅 UI 표시
+  const showChatUI = status === 'chatting' || status === 'partner_left'
+
+  return (
+    <MainLayout activeTab="random-chat">
+      {!showChatUI ? (
+        /* ───── 비채팅 상태 화면들 ───── */
+        <div className="flex h-full w-full flex-col items-center justify-center px-[50px] py-[20px]">
+
+          {/* idle: 초기 화면 */}
+          {status === 'idle' && (
+            <div className="flex flex-col items-center">
+              <div className="h-[139px] w-[139px]">
+                <img src={welcomeIcon} alt="Random Chat" className="h-full w-full object-contain" />
+              </div>
+              <p
+                className="mt-[20px] text-center text-[20px] text-[#AEAEAE]"
+                style={{ fontFamily: 'Segoe UI, sans-serif' }}
+              >
+                Meet someone new and start chatting!
+              </p>
+              <button
+                onClick={handleJoinQueue}
+                className="mt-[27px] flex h-[52px] w-[220px] items-center justify-center rounded-[10px] bg-gradient-to-b from-[#7CC2F0] to-[#5BA3D9] text-[18px] font-bold text-white shadow-md hover:from-[#6BB5E8] hover:to-[#4A92C8] font-['Segoe_UI']"
+                style={{
+                  border: '1px solid #4A92C8',
+                  boxShadow: '0px 2px 6px rgba(0,0,0,0.15), inset 0 1px 0 rgba(255,255,255,0.3)',
+                }}
+              >
+                Start Random Chat
+              </button>
+            </div>
+          )}
+
+          {/* connecting: 연결 중 */}
+          {status === 'connecting' && (
+            <div className="flex flex-col items-center gap-4">
+              <div className="h-10 w-10 animate-spin rounded-full border-4 border-[#D8F0FE] border-t-[#7CC2F0]" />
+              <p className="text-[14px] font-medium text-[#3E6F97] font-['Segoe_UI']">
+                Connecting...
+              </p>
+            </div>
+          )}
+
+          {/* waiting: 매칭 대기 */}
+          {status === 'waiting' && (
+            <div className="flex flex-col items-center">
+              <div className="h-[139px] w-[139px]">
+                <img src={welcomeIcon} alt="Waiting" className="h-full w-full animate-pulse object-contain" />
+              </div>
+              <p
+                className="mt-[20px] text-center text-[18px] font-semibold text-[#3E6F97]"
+                style={{ fontFamily: 'Segoe UI, sans-serif' }}
+              >
+                Looking for someone to chat with...
+              </p>
+              <div className="mt-3 flex items-center gap-2">
+                <div className="h-2 w-2 animate-bounce rounded-full bg-[#7CC2F0]" style={{ animationDelay: '0ms' }} />
+                <div className="h-2 w-2 animate-bounce rounded-full bg-[#7CC2F0]" style={{ animationDelay: '150ms' }} />
+                <div className="h-2 w-2 animate-bounce rounded-full bg-[#7CC2F0]" style={{ animationDelay: '300ms' }} />
+              </div>
+              <button
+                onClick={handleLeaveQueue}
+                className="mt-[27px] flex h-[42px] w-[140px] items-center justify-center rounded-[5px] border border-[#7CC2F0] bg-gradient-to-b from-white to-[#E1F2FF] text-[14px] font-semibold text-[#3E6F97] active:shadow-inner font-['Segoe_UI']"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {/* disconnected: 연결 끊김 */}
+          {status === 'disconnected' && (
+            <div className="flex flex-col items-center gap-4">
+              <div className="h-[139px] w-[139px]">
+                <img src={welcomeIcon} alt="Disconnected" className="h-full w-full object-contain opacity-50" />
+              </div>
+              <p
+                className="text-center text-[18px] font-semibold text-[#E74C3C]"
+                style={{ fontFamily: 'Segoe UI, sans-serif' }}
+              >
+                Connection lost.
+              </p>
+              <button
+                onClick={reconnect}
+                className="flex h-[42px] w-[160px] items-center justify-center rounded-[5px] border border-[#7CC2F0] bg-gradient-to-b from-white to-[#E1F2FF] text-[14px] font-semibold text-[#3E6F97] active:shadow-inner font-['Segoe_UI']"
+              >
+                Reconnect
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        /* ───── 채팅 UI (chatting / partner_left) ───── */
+        <div className="flex h-full w-full flex-col px-[30px] py-[15px] md:px-[50px] md:py-[20px]">
+
+          {/* 채팅 헤더 */}
+          <div className="flex flex-shrink-0 items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2">
+                <span className="text-[28px]">👤</span>
+                <div>
+                  <h3 className="text-[16px] font-bold text-[#3E6F97] font-['Segoe_UI']">
+                    Random Chat
+                  </h3>
+                  <div className="flex items-center gap-1">
+                    <span
+                      className={`h-[8px] w-[8px] rounded-full ${
+                        status === 'chatting'
+                          ? 'bg-[#39FF14] shadow-[0_0_4px_rgba(57,255,20,0.8)]'
+                          : 'bg-[#AEAEAE]'
+                      }`}
+                    />
+                    <span className="text-[12px] text-[#8EADC1] font-['Segoe_UI']">
+                      {status === 'chatting' ? 'Partner connected' : 'Partner left'}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 나가기 버튼 (chatting 상태에서만) */}
+            {status === 'chatting' && (
+              <button
+                onClick={() => setShowExitModal(true)}
+                className="flex h-[32px] items-center justify-center rounded-[3px] border border-[#7CC2F0] bg-gradient-to-b from-white to-[#E1F2FF] px-4 text-[12px] font-semibold text-[#3E6F97] active:shadow-inner font-['Segoe_UI']"
+              >
+                Exit Chat
+              </button>
+            )}
+
+            {/* partner_left 상태에서 버튼들 */}
+            {status === 'partner_left' && (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleBackToIdle}
+                  className="flex h-[32px] items-center justify-center rounded-[3px] border border-[#7CC2F0] bg-gradient-to-b from-white to-[#E1F2FF] px-4 text-[12px] font-semibold text-[#3E6F97] active:shadow-inner font-['Segoe_UI']"
+                >
+                  Back
+                </button>
+                <button
+                  onClick={handleNewChat}
+                  className="flex h-[32px] items-center justify-center rounded-[3px] bg-gradient-to-b from-[#7CC2F0] to-[#5BA3D9] px-4 text-[12px] font-bold text-white shadow-md hover:from-[#6BB5E8] hover:to-[#4A92C8] font-['Segoe_UI']"
+                  style={{ border: '1px solid #4A92C8' }}
+                >
+                  New Chat
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* 구분선 */}
+          <div
+            className="mt-2 h-[1px] w-full flex-shrink-0"
+            style={{
+              background: 'linear-gradient(90deg, rgba(153, 170, 182, 0) 0%, rgba(153, 170, 182, 1) 50%, rgba(153, 170, 182, 0) 100%)',
+              filter: 'blur(0.5px)',
+            }}
+          />
+
+          {/* 메시지 영역 */}
+          <div className="custom-scrollbar mt-2 min-h-0 flex-1 overflow-y-auto rounded-md p-3">
+            {messages.length === 0 ? (
+              <div className="flex h-full items-center justify-center">
+                <p className="text-[#8EADC1] font-['Segoe_UI']">Say hello to your partner!</p>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {messages.map((message) => {
+                  // 시스템 메시지 (가운데 정렬)
+                  if (message.sender === 'system') {
+                    return (
+                      <div key={message.id} className="flex justify-center py-1">
+                        <span
+                          className="rounded-full bg-[#E1F2FF] px-4 py-1 text-[12px] text-[#3E6F97] font-['Segoe_UI']"
+                          style={{ border: '1px solid #7CC2F0' }}
+                        >
+                          {message.content}
+                        </span>
+                      </div>
+                    )
+                  }
+
+                  const isMe = message.sender === 'me'
+                  return (
+                    <div
+                      key={message.id}
+                      className={`flex ${isMe ? 'justify-end' : 'justify-start'}`}
+                    >
+                      {/* 상대방 아바타 */}
+                      {!isMe && (
+                        <div className="mr-2 flex h-[32px] w-[32px] flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-b from-[#D8F0FE] to-[#B9E5FE]"
+                          style={{ border: '1px solid #7CC2F0' }}
+                        >
+                          <span className="text-[14px]">👤</span>
+                        </div>
+                      )}
+                      <div
+                        className={`max-w-[65%] rounded-lg px-3 py-2 ${
+                          isMe
+                            ? 'bg-gradient-to-b from-[#7CC2F0] to-[#5BA3D9]'
+                            : 'bg-white'
+                        }`}
+                        style={{
+                          border: isMe ? '1px solid #4A92C8' : '1px solid #D2D2D2',
+                          boxShadow: '0 1px 2px rgba(0,0,0,0.08)',
+                        }}
+                      >
+                        <p
+                          className={`whitespace-pre-wrap break-words text-[13px] ${
+                            isMe ? 'text-white' : 'text-[#333]'
+                          }`}
+                        >
+                          {message.content}
+                        </p>
+                        <p
+                          className={`mt-1 text-right text-[10px] ${
+                            isMe ? 'text-white/70' : 'text-[#AEAEAE]'
+                          }`}
+                        >
+                          {formatTime(message.timestamp)}
+                        </p>
+                      </div>
+                      {/* 내 아바타 */}
+                      {isMe && (
+                        <div className="ml-2 flex h-[32px] w-[32px] flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-b from-[#D8F0FE] to-[#B9E5FE]"
+                          style={{ border: '1px solid #7CC2F0' }}
+                        >
+                          <span className="text-[14px]">🧑</span>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+                <div ref={messagesEndRef} />
+              </div>
+            )}
+          </div>
+
+          {/* 입력 영역 - chatting 상태에서만 활성화 */}
+          {status === 'chatting' && (
+            <div className="mt-2 flex-shrink-0">
+              <div
+                className="rounded-md bg-white p-2"
+                style={{
+                  border: '1px solid #7CC2F0',
+                  boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.1)',
+                }}
+              >
+                <textarea
+                  value={inputValue}
+                  onChange={(e) => {
+                    if (e.target.value.length <= MAX_MESSAGE_LENGTH) {
+                      setInputValue(e.target.value)
+                    }
+                  }}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Type your message..."
+                  className="h-[50px] w-full resize-none text-[13px] text-[#333] placeholder-[#AEAEAE] focus:outline-none"
+                  maxLength={MAX_MESSAGE_LENGTH}
+                />
+              </div>
+              <div className="mt-1 flex items-center justify-between">
+                <span className="text-[11px] text-[#AEAEAE] font-['Segoe_UI']">
+                  {inputValue.length}/{MAX_MESSAGE_LENGTH}
+                </span>
+                <button
+                  onClick={handleSendMessage}
+                  disabled={!inputValue.trim()}
+                  className="rounded-md bg-gradient-to-b from-[#7CC2F0] to-[#5BA3D9] px-4 py-1 text-[13px] font-bold text-white shadow-md hover:from-[#6BB5E8] hover:to-[#4A92C8] disabled:cursor-not-allowed disabled:opacity-50 font-['Segoe_UI']"
+                  style={{ border: '1px solid #4A92C8' }}
+                >
+                  Send
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* partner_left 상태 - 입력 비활성화 안내 */}
+          {status === 'partner_left' && (
+            <div className="mt-2 flex-shrink-0">
+              <div
+                className="flex items-center justify-center rounded-md bg-[#F5F5F5] p-3"
+                style={{ border: '1px solid #D2D2D2' }}
+              >
+                <p className="text-[13px] text-[#AEAEAE] font-['Segoe_UI']">
+                  Chat ended. Partner has left.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 퇴장 확인 모달 */}
+      <SystemModal
+        isOpen={showExitModal}
+        onClose={() => setShowExitModal(false)}
+        message="Do you want to leave this chat?"
+        onOk={handleExitConfirm}
+        onCancel={() => setShowExitModal(false)}
+      />
+
+      {/* 에러 알림 모달 */}
+      <AlertModal
+        isOpen={!!error}
+        onClose={() => setError(null)}
+        message={error?.message || 'An error occurred.'}
+        subMessage={`Error code: ${error?.code || 'UNKNOWN'}`}
+        variant="warning"
+        buttonText="OK"
+        onButtonClick={() => setError(null)}
+      />
+    </MainLayout>
+  )
+}
+
+export default RandomChatPage

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { tokenStorage } from './token'
 
-const BASE_URL = 'https://api.sokdak.site'
+const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
 export const apiClient = axios.create({
   baseURL: BASE_URL,
@@ -9,6 +9,24 @@ export const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 })
+
+// Access Token 갱신 함수 (WebSocket에서도 사용)
+export async function refreshAccessToken(): Promise<string | null> {
+  try {
+    const response = await axios.post(
+      `${BASE_URL}/auth/refresh`,
+      {},
+      { withCredentials: true }
+    )
+    const { accessToken } = response.data
+    tokenStorage.setAccessToken(accessToken)
+    return accessToken
+  } catch {
+    tokenStorage.clearTokens()
+    window.location.href = '/login'
+    return null
+  }
+}
 
 // 요청 인터셉터: Access Token 자동 추가
 apiClient.interceptors.request.use(
@@ -32,25 +50,10 @@ apiClient.interceptors.response.use(
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true
 
-      try {
-        // 쿠키가 자동 전송되므로 body 없이 요청
-        const response = await axios.post(
-          `${BASE_URL}/auth/refresh`,
-          {},
-          { withCredentials: true }
-        )
-
-        const { accessToken } = response.data
-        tokenStorage.setAccessToken(accessToken)
-
-        // 원래 요청 재시도
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`
+      const newToken = await refreshAccessToken()
+      if (newToken) {
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
         return apiClient(originalRequest)
-      } catch (refreshError) {
-        // 리프레시 토큰도 만료된 경우 로그아웃 처리
-        tokenStorage.clearTokens()
-        window.location.href = '/login'
-        return Promise.reject(refreshError)
       }
     }
 

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export { usePersonaOptions } from './usePersonaOptions'
+export { useWebSocket } from './useWebSocket'

--- a/src/shared/hooks/useWebSocket.ts
+++ b/src/shared/hooks/useWebSocket.ts
@@ -1,0 +1,216 @@
+import { useCallback } from 'react'
+import { tokenStorage } from '../api/token'
+import { refreshAccessToken } from '../api/client'
+import { useRandomChatStore } from '../stores/randomChatStore'
+
+// http(s)://... → ws(s)://... 자동 변환
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+const WS_BASE_URL = API_URL.replace(/^http/, 'ws') + '/ws/random-chat'
+
+const MAX_RECONNECT_ATTEMPTS = 3
+const RECONNECT_DELAY = 3000
+
+// 클라이언트 → 서버 메시지 타입
+type ClientMessage =
+  | { type: 'JOIN_QUEUE' }
+  | { type: 'LEAVE_QUEUE' }
+  | { type: 'SEND_MESSAGE'; content: string }
+  | { type: 'EXIT_ROOM' }
+
+// 서버 → 클라이언트 메시지 타입 (discriminated union)
+type ServerMessage =
+  | { type: 'QUEUE_JOINED'; timestamp: string }
+  | { type: 'QUEUE_LEFT'; timestamp: string }
+  | { type: 'MATCHED'; roomId: string; timestamp: string }
+  | { type: 'MESSAGE_RECEIVED'; messageId: string; content: string; timestamp: string }
+  | { type: 'PARTNER_LEFT'; timestamp: string }
+  | { type: 'ERROR'; code: string; message: string; timestamp: string }
+
+// 에러 코드별 처리
+const RESET_TO_IDLE_ERRORS = ['NOT_IN_QUEUE', 'NOT_IN_ROOM', 'ROOM_NOT_FOUND']
+const IGNORABLE_ERRORS = ['ALREADY_IN_QUEUE']
+const KEEP_CHATTING_ERRORS = ['ALREADY_IN_ROOM']
+
+// ─── 모듈 레벨 싱글턴 (컴포넌트 lifecycle과 무관) ───
+let ws: WebSocket | null = null
+let reconnectAttempts = 0
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let intentionalClose = false
+let pendingMessages: ClientMessage[] = []
+
+function handleError(code: string, message: string) {
+  const store = useRandomChatStore.getState()
+
+  if (IGNORABLE_ERRORS.includes(code)) return
+  if (KEEP_CHATTING_ERRORS.includes(code)) return
+
+  if (RESET_TO_IDLE_ERRORS.includes(code)) {
+    store.reset()
+    store.setError({ code, message })
+    return
+  }
+
+  store.setError({ code, message })
+}
+
+function connectWs() {
+  const token = tokenStorage.getAccessToken()
+  if (!token) return
+
+  // 이미 연결 중이거나 연결된 상태면 무시
+  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+    return
+  }
+
+  const store = useRandomChatStore.getState()
+  store.setStatus('connecting')
+  intentionalClose = false
+
+  const socket = new WebSocket(`${WS_BASE_URL}?token=${token}`)
+  ws = socket
+
+  socket.onopen = () => {
+    reconnectAttempts = 0
+    useRandomChatStore.getState().setStatus('idle')
+
+    // 대기 중이던 메시지 전송
+    const queued = [...pendingMessages]
+    pendingMessages = []
+    queued.forEach((msg) => {
+      socket.send(JSON.stringify(msg))
+    })
+  }
+
+  socket.onmessage = (event) => {
+    try {
+      const data: ServerMessage = JSON.parse(event.data)
+      const s = useRandomChatStore.getState()
+
+      switch (data.type) {
+        case 'QUEUE_JOINED':
+          // 이미 MATCHED로 chatting이면 무시 (즉시 매칭 케이스)
+          if (s.status !== 'chatting') {
+            s.setStatus('waiting')
+          }
+          break
+
+        case 'QUEUE_LEFT':
+          s.setStatus('idle')
+          break
+
+        case 'MATCHED':
+          // 어떤 상태에서든 MATCHED 수신 가능 (전역 리스닝)
+          s.setRoomId(data.roomId)
+          s.setStatus('chatting')
+          break
+
+        case 'MESSAGE_RECEIVED':
+          if (s.status === 'chatting') {
+            s.addMessage({
+              id: data.messageId,
+              content: data.content,
+              timestamp: new Date(data.timestamp).getTime(),
+              sender: 'partner',
+            })
+          }
+          break
+
+        case 'PARTNER_LEFT':
+          s.addMessage({
+            id: `system-${Date.now()}`,
+            content: '상대방이 나갔습니다.',
+            timestamp: new Date(data.timestamp).getTime(),
+            sender: 'system',
+          })
+          s.setRoomId(null)
+          s.setStatus('partner_left')
+          break
+
+        case 'ERROR':
+          handleError(data.code, data.message)
+          break
+      }
+    } catch {
+      // 파싱 실패 무시
+    }
+  }
+
+  socket.onclose = () => {
+    ws = null
+
+    if (intentionalClose) return
+
+    // 비정상 종료 시 토큰 갱신 후 재연결 시도
+    if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+      useRandomChatStore.getState().setStatus('disconnected')
+      reconnectTimer = setTimeout(async () => {
+        reconnectAttempts += 1
+        // 토큰 만료가 원인일 수 있으므로 갱신 시도 후 재연결
+        await refreshAccessToken()
+        connectWs()
+      }, RECONNECT_DELAY)
+    } else {
+      useRandomChatStore.getState().setStatus('disconnected')
+    }
+  }
+
+  socket.onerror = () => {
+    // onclose에서 처리
+  }
+}
+
+function disconnectWs() {
+  intentionalClose = true
+  pendingMessages = []
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+  if (ws) {
+    ws.close()
+    ws = null
+  }
+}
+
+function sendWs(message: ClientMessage) {
+  if (ws?.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(message))
+  } else {
+    // 연결 안 됐으면 대기열에 넣고 자동 연결
+    pendingMessages.push(message)
+    connectWs()
+  }
+}
+
+// 브라우저 종료/새로고침 시 정리 (모듈 레벨에서 1회 등록)
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', () => {
+    disconnectWs()
+  })
+}
+
+// ─── React Hook (단순 래퍼) ───
+export function useWebSocket() {
+  const send = useCallback((message: ClientMessage) => {
+    sendWs(message)
+  }, [])
+
+  const exitRoom = useCallback(() => {
+    sendWs({ type: 'EXIT_ROOM' })
+    useRandomChatStore.getState().reset()
+  }, [])
+
+  const reconnect = useCallback(() => {
+    reconnectAttempts = 0
+    disconnectWs()
+    intentionalClose = false
+    connectWs()
+  }, [])
+
+  const disconnect = useCallback(() => {
+    disconnectWs()
+    useRandomChatStore.getState().reset()
+  }, [])
+
+  return { send, exitRoom, reconnect, disconnect }
+}

--- a/src/shared/stores/randomChatStore.ts
+++ b/src/shared/stores/randomChatStore.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand'
+
+// idle: 초기 / connecting: WS 연결 중 / waiting: 매칭 대기
+// chatting: 1:1 채팅 중 / partner_left: 상대 퇴장 (메시지 유지)
+// disconnected: 연결 끊김
+export type RandomChatStatus =
+  | 'idle'
+  | 'connecting'
+  | 'waiting'
+  | 'chatting'
+  | 'partner_left'
+  | 'disconnected'
+
+export interface ChatMessage {
+  id: string
+  content: string
+  timestamp: number
+  sender: 'me' | 'partner' | 'system'
+}
+
+export interface ChatError {
+  code: string
+  message: string
+}
+
+interface RandomChatState {
+  status: RandomChatStatus
+  roomId: string | null
+  messages: ChatMessage[]
+  error: ChatError | null
+
+  setStatus: (status: RandomChatStatus) => void
+  setRoomId: (roomId: string | null) => void
+  addMessage: (message: ChatMessage) => void
+  setError: (error: ChatError | null) => void
+  reset: () => void
+}
+
+export const useRandomChatStore = create<RandomChatState>((set) => ({
+  status: 'idle',
+  roomId: null,
+  messages: [],
+  error: null,
+
+  setStatus: (status) => set({ status }),
+  setRoomId: (roomId) => set({ roomId }),
+  addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
+  setError: (error) => set({ error }),
+  reset: () => set({ status: 'idle', roomId: null, messages: [], error: null }),
+}))

--- a/src/shared/ui/MainLayout.tsx
+++ b/src/shared/ui/MainLayout.tsx
@@ -10,7 +10,7 @@ import { authApi } from '../api';
 
 interface MainLayoutProps {
   children: ReactNode;
-  activeTab: 'chat' | 'journal';
+  activeTab: 'chat' | 'journal' | 'random-chat';
 }
 
 const CHAT_CARD_BACKGROUND = 'linear-gradient(180deg, rgba(255, 255, 255, 0.6) 0%, rgba(140, 207, 255, 0.15) 51%, rgba(140, 207, 255, 0.4) 98%)';
@@ -70,6 +70,22 @@ export const MainLayout = ({
             <span className="text-sm text-[#5389B5] font-['Segoe_UI'] md:text-[18px]">journal</span>
             <img src={iconRepertoire} alt="Journal" className="h-5 w-5 md:h-[22px] md:w-[22px]" />
             {activeTab === 'journal' && (
+              <div className="absolute bottom-[-1.5px] left-0 right-0 h-[3px] bg-[#FCFCFC]" />
+            )}
+          </div>
+
+          {/* Random Chat Tab */}
+          <div
+            onClick={() => navigate('/random-chat')}
+            className={`relative z-10 ml-2 flex h-9 w-24 cursor-pointer items-center justify-center gap-1 rounded-t-[5px] px-3 border-[1.5px] border-[#A6C7E4] border-b-0 transition-all md:ml-[7px] md:h-[40px] md:w-[148px] md:justify-start md:gap-2 md:px-[18px] ${
+              activeTab === 'random-chat'
+                ? 'bg-gradient-to-b from-[#C7EEFF] to-[#FCFCFC] opacity-100'
+                : 'bg-gradient-to-b from-[#FCFCFC] to-[#C7EEFF] opacity-60 hover:opacity-80'
+            }`}
+          >
+            <span className="text-sm text-[#5389B5] font-['Segoe_UI'] md:text-[18px]">random</span>
+            <img src={iconChat} alt="Random Chat" className="h-5 w-5 object-contain md:h-[22px] md:w-[22px]" />
+            {activeTab === 'random-chat' && (
               <div className="absolute bottom-[-1.5px] left-0 right-0 h-[3px] bg-[#FCFCFC]" />
             )}
           </div>


### PR DESCRIPTION
### 관련 이슈 : #11 

## Summary
- WebSocket 기반 1:1 랜덤 채팅 기능 추가
- 모듈 레벨 WebSocket 싱글턴으로 탭 전환 시에도 연결 유지
- 하드코딩 URL을 환경변수(VITE_API_URL)로 분리하고, WebSocket 재연결 시 토큰 자동 갱신 추가

## 변경 파일
| 파일 | 변경 |
|------|------|
| `src/shared/stores/randomChatStore.ts` | 신규 - Zustand 스토어 |
| `src/shared/hooks/useWebSocket.ts` | 신규 - WebSocket 싱글턴 + 훅 |
| `src/pages/RandomChatPage.tsx` | 신규 - 랜덤 채팅 페이지 |
| `src/app/App.tsx` | `/random-chat` 라우트 추가 |
| `src/shared/ui/MainLayout.tsx` | random 탭 추가 |
| `src/shared/api/client.ts` | 환경변수 URL + refreshAccessToken 분리 |
| `src/shared/hooks/index.ts` | useWebSocket export |

## Test plan
- [ ] 두 유저(일반 창 + 시크릿 창)로 매칭 테스트
- [ ] 양쪽에서 메시지 송수신 확인
- [ ] 한쪽 나가기 시 상대방에게 "상대방이 나갔습니다" 표시 확인
- [ ] 탭 전환(chat/journal) 후 돌아와도 채팅 유지 확인
- [ ] 한글 입력 시 메시지 중복 전송 없는지 확인
- [ ] Vercel 배포 후 wss:// 연결 정상 동작 확인